### PR TITLE
Add encryption option and a cleaner cli interface

### DIFF
--- a/command.go
+++ b/command.go
@@ -71,7 +71,7 @@ func processCmdMacro(macroName string, args []string, conf *config) error {
 	margs = appendExpEnv(margs, args)
 	margs = appendExpEnv(margs, m.Suffix)
 
-	if conf.flags&flagVerbose != 0 {
+	if conf.verbose {
 		log.Printf("expanding macro: %s", mn)
 	}
 
@@ -94,7 +94,7 @@ func processCmd(params []string, conf *config) error {
 		return processCmdMacro(cmdName, cmdArgs, conf)
 	}
 
-	if conf.flags&flagVerbose != 0 {
+	if conf.verbose {
 		log.Printf("executing command: %s %s", cmdName, strings.Join(cmdArgs, " "))
 	}
 

--- a/config.go
+++ b/config.go
@@ -36,16 +36,18 @@ type config struct {
 	Tasks  map[string]task
 	Macros map[string]macro
 
-	handled map[string]bool
-	srcDir  string
-	dstDir  string
-	variant string
-	task    string
-	force   bool
-	clobber bool
-	verbose bool
-	nocmds  bool
-	nolinks bool
+	handled  map[string]bool
+	srcDir   string
+	dstDir   string
+	variant  string
+	task     string
+	force    bool
+	clobber  bool
+	verbose  bool
+	nocmds   bool
+	nolinks  bool
+	password string
+	remove   bool
 }
 
 func newConfig(filename string) (*config, error) {

--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ type config struct {
 	Tasks  map[string]task
 	Macros map[string]macro
 
+	file     string
 	handled  map[string]bool
 	srcDir   string
 	dstDir   string

--- a/config.go
+++ b/config.go
@@ -40,7 +40,12 @@ type config struct {
 	srcDir  string
 	dstDir  string
 	variant string
-	flags   int
+	task    string
+	force   bool
+	clobber bool
+	verbose bool
+	nocmds  bool
+	nolinks bool
 }
 
 func newConfig(filename string) (*config, error) {

--- a/enc.go
+++ b/enc.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/andrewrynhard/go-mask"
+)
+
+func decrypt(cipherstring string, keystring string) string {
+	// Byte array of the string
+	ciphertext := []byte(cipherstring)
+
+	// Key
+	key := []byte(keystring)
+
+	// Create the AES cipher
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		panic(err)
+	}
+
+	// Before even testing the decryption,
+	// if the text is too small, then it is incorrect
+	if len(ciphertext) < aes.BlockSize {
+		panic("Text is too short")
+	}
+
+	// Get the 16 byte IV
+	iv := ciphertext[:aes.BlockSize]
+
+	// Remove the IV from the ciphertext
+	ciphertext = ciphertext[aes.BlockSize:]
+
+	// Return a decrypted stream
+	stream := cipher.NewCFBDecrypter(block, iv)
+
+	// Decrypt bytes from ciphertext
+	stream.XORKeyStream(ciphertext, ciphertext)
+
+	return string(ciphertext)
+}
+
+func encrypt(plainstring, keystring string) string {
+	// Byte array of the string
+	plaintext := []byte(plainstring)
+
+	// Key
+	key := []byte(keystring)
+
+	// Create the AES cipher
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		panic(err)
+	}
+
+	// Empty array of 16 + plaintext length
+	// Include the IV at the beginning
+	ciphertext := make([]byte, aes.BlockSize+len(plaintext))
+
+	// Slice of first 16 bytes
+	iv := ciphertext[:aes.BlockSize]
+
+	// Write 16 rand bytes to fill iv
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		panic(err)
+	}
+
+	// Return an encrypted stream
+	stream := cipher.NewCFBEncrypter(block, iv)
+
+	// Encrypt bytes from plaintext to ciphertext
+	stream.XORKeyStream(ciphertext[aes.BlockSize:], plaintext)
+
+	return string(ciphertext)
+}
+
+func writeToFile(data, file string) {
+	ioutil.WriteFile(file, []byte(data), 0666)
+}
+
+func readFromFile(file string) ([]byte, error) {
+	data, err := ioutil.ReadFile(file)
+	return data, err
+}
+
+func isFile(file string) (bool, error) {
+	s, err := os.Stat(file)
+
+	if os.IsNotExist(err) {
+		return false, err
+	}
+
+	if s.IsDir() {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func readKey() (string, error) {
+	maskedReader := mask.NewMaskedReader()
+
+	key, err := maskedReader.GetInputConfirmMasked()
+	if err != nil {
+		return "", err
+	}
+
+	hasher := md5.New()
+	hasher.Write([]byte(key))
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func encryptFile(file string, key string) error {
+	content, err := readFromFile(file)
+	if err != nil {
+		return err
+	}
+
+	encrypted := encrypt(string(content), string(key))
+	writeToFile(encrypted, file+".enc")
+
+	if prompt(strings.Join([]string{"Remove", file, "?"}, " ")) {
+		os.Remove(file)
+	}
+
+	return nil
+}
+
+func decryptFile(file string, key string) error {
+	content, err := readFromFile(file)
+	if err != nil {
+		return err
+	}
+
+	decrypted := decrypt(string(content), string(key))
+	writeToFile(decrypted, file[:len(file)-4])
+
+	return nil
+}
+
+func encryptEnc(param string, conf *config, key string) error {
+	sourceFile := filepath.Join(conf.srcDir, param)
+
+	exists, err := isFile(sourceFile)
+	if !exists {
+		return err
+	}
+
+	encryptFile(sourceFile, key)
+
+	return nil
+}
+
+func processEnc(param string, conf *config, key string) error {
+	sourceFile := filepath.Join(conf.srcDir, param) + ".enc"
+
+	exists, err := isFile(sourceFile)
+	if !exists {
+		return err
+	}
+
+	decryptFile(sourceFile, key)
+
+	return nil
+}

--- a/environment.go
+++ b/environment.go
@@ -37,7 +37,7 @@ func processEnv(env []string, conf *config) error {
 	case len(args) == 0:
 		return fmt.Errorf("invalid environment statement")
 	case len(args) == 1:
-		if conf.flags&flagVerbose != 0 {
+		if conf.verbose {
 			log.Printf("unsetting variable: %s", args[0])
 		}
 		os.Unsetenv(args[0])
@@ -48,7 +48,7 @@ func processEnv(env []string, conf *config) error {
 		value = strings.Join(args[1:], ",")
 	}
 
-	if conf.flags&flagVerbose != 0 {
+	if conf.verbose {
 		log.Printf("setting variable %s to %s", args[0], value)
 	}
 

--- a/homemaker.go
+++ b/homemaker.go
@@ -160,7 +160,7 @@ func main() {
 		},
 		{
 			Name:    "decrypt",
-			Aliases: []string{"e"},
+			Aliases: []string{"d"},
 			Usage:   "decrypt task files",
 			Flags: []cli.Flag{
 				cli.StringFlag{

--- a/homemaker.go
+++ b/homemaker.go
@@ -123,6 +123,17 @@ func main() {
 			Name:    "encrypt",
 			Aliases: []string{"e"},
 			Usage:   "encrypt task files",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "password",
+					Value: "",
+					Usage: "a password to encrypt a task",
+				},
+				cli.BoolFlag{
+					Name:  "remove",
+					Usage: "remove the original file after encryption",
+				},
+			},
 			Action: func(c *cli.Context) {
 				if len(c.Args()) != 1 {
 					log.Fatal("Invalid number of arguments")
@@ -137,7 +148,44 @@ func main() {
 					log.Fatal(err)
 				}
 
+				conf.password = c.String("password")
+				conf.remove = c.Bool("remove")
+
 				if err := encryptTask(c.GlobalString("task"), conf); err != nil {
+					log.Fatal(err)
+					cli.ShowAppHelp(c)
+					os.Exit(1)
+				}
+			},
+		},
+		{
+			Name:    "decrypt",
+			Aliases: []string{"e"},
+			Usage:   "decrypt task files",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "password",
+					Value: "",
+					Usage: "a password to decrypt a task",
+				},
+			},
+			Action: func(c *cli.Context) {
+				if len(c.Args()) != 1 {
+					log.Fatal("Invalid number of arguments")
+					cli.ShowAppHelp(c)
+					os.Exit(1)
+				}
+
+				confFile := makeAbsPath(c.Args()[0])
+
+				conf, err := newConfig(confFile)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				conf.password = c.String("password")
+
+				if err := decryptTask(c.GlobalString("task"), conf); err != nil {
 					log.Fatal(err)
 					cli.ShowAppHelp(c)
 					os.Exit(1)

--- a/secret.go
+++ b/secret.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/andrewrynhard/go-mask"
 )
@@ -99,7 +98,7 @@ func getMaskedInput() ([]byte, error) {
 	return key, nil
 }
 
-func keyFromPasssword(password []byte) string {
+func keyFromPassword(password []byte) string {
 	hasher := md5.New()
 
 	hasher.Write([]byte(password))
@@ -107,7 +106,7 @@ func keyFromPasssword(password []byte) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
-func encryptFile(file string, key string, conf *config) error {
+func encryptFile(file string, key string) error {
 	content, err := readFromFile(file)
 	if err != nil {
 		return err
@@ -115,10 +114,6 @@ func encryptFile(file string, key string, conf *config) error {
 
 	encrypted := encrypt(string(content), string(key))
 	writeToFile(encrypted, file+".enc")
-
-	if conf.remove || prompt(strings.Join([]string{"Remove", file, "?"}, " ")) {
-		os.Remove(file)
-	}
 
 	return nil
 }
@@ -143,25 +138,12 @@ func encryptSecret(param string, conf *config, key string) error {
 		return err
 	}
 
-	encryptFile(sourceFile, key, conf)
+	encryptFile(sourceFile, key)
 
 	return nil
 }
 
 func decryptSecret(param string, conf *config, key string) error {
-	sourceFile := filepath.Join(conf.srcDir, param) + ".enc"
-
-	exists, err := isFile(sourceFile)
-	if !exists {
-		return err
-	}
-
-	decryptFile(sourceFile, key)
-
-	return nil
-}
-
-func processEnc(param string, conf *config, key string) error {
 	sourceFile := filepath.Join(conf.srcDir, param) + ".enc"
 
 	exists, err := isFile(sourceFile)

--- a/task.go
+++ b/task.go
@@ -214,7 +214,7 @@ func decryptTask(taskName string, conf *config) error {
 		}
 
 		if conf.verbose {
-			log.Printf("encrypting task: %s", tn)
+			log.Printf("decrypting task: %s", tn)
 		}
 
 		key, err := t.hashPassword(tn, conf)

--- a/task.go
+++ b/task.go
@@ -32,12 +32,13 @@ type task struct {
 	Links [][]string
 	Cmds  [][]string
 	Envs  [][]string
+	Encs  []string
 }
 
 func (t *task) deps(conf *config) []string {
 	deps := t.Deps
 
-	if conf.flags&flagNoCmds == 0 {
+	if conf.nocmds {
 		for _, currCmd := range t.Cmds {
 			deps = append(deps, findCmdDeps(currCmd, conf)...)
 		}
@@ -46,9 +47,15 @@ func (t *task) deps(conf *config) []string {
 	return deps
 }
 
-func (t *task) process(conf *config) error {
+func (t *task) process(conf *config, key string) error {
 	for _, currTask := range t.deps(conf) {
 		if err := processTask(currTask, conf); err != nil {
+			return err
+		}
+	}
+
+	for _, currEnc := range t.Encs {
+		if err := processEnc(currEnc, conf, key); err != nil {
 			return err
 		}
 	}
@@ -59,7 +66,7 @@ func (t *task) process(conf *config) error {
 		}
 	}
 
-	if conf.flags&flagNoCmds == 0 {
+	if !conf.nocmds {
 		for _, currCmd := range t.Cmds {
 			if err := processCmd(currCmd, conf); err != nil {
 				return err
@@ -67,7 +74,7 @@ func (t *task) process(conf *config) error {
 		}
 	}
 
-	if conf.flags&flagNoLinks == 0 {
+	if !conf.nolinks {
 		for _, currLink := range t.Links {
 			if err := processLink(currLink, conf); err != nil {
 				return err
@@ -86,19 +93,122 @@ func processTask(taskName string, conf *config) error {
 		}
 
 		if conf.handled[tn] {
-			if conf.flags&flagVerbose != 0 {
+			if conf.verbose {
 				log.Printf("skipping processed task: %s", tn)
 			}
 
 			return nil
 		}
 
-		if conf.flags&flagVerbose != 0 {
+		if conf.verbose {
 			log.Printf("processing task: %s", tn)
 		}
 
+		var key string
+		if len(t.Encs) != 0 {
+			fmt.Printf("Enter your password for %s: ", tn)
+			k, err := readKey()
+			if err != nil {
+				return err
+			}
+			key = k
+		}
+
 		conf.handled[tn] = true
-		return t.process(conf)
+		return t.process(conf, key)
+	}
+
+	return fmt.Errorf("task or variant not found: %s", taskName)
+}
+
+func (t *task) encrypt(conf *config, key string) error {
+	for _, currTask := range t.deps(conf) {
+		if err := encryptTask(currTask, conf); err != nil {
+			return err
+		}
+	}
+
+	for _, currEnc := range t.Encs {
+		if err := encryptEnc(currEnc, conf, key); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func encryptTask(taskName string, conf *config) error {
+	for _, tn := range makeVariantNames(taskName, conf.variant) {
+		t, ok := conf.Tasks[tn]
+		if !ok {
+			continue
+		}
+
+		if conf.handled[tn] {
+			if conf.verbose {
+				log.Printf("skipping processed task: %s", tn)
+			}
+
+			return nil
+		}
+
+		if conf.verbose {
+			log.Printf("encrypting task: %s", tn)
+		}
+
+		var key string
+		if len(t.Encs) != 0 {
+			fmt.Printf("Enter your password for %s: ", tn)
+			k, err := readKey()
+			if err != nil {
+				return err
+			}
+			key = k
+		}
+
+		conf.handled[tn] = true
+		return t.encrypt(conf, key)
+	}
+
+	return fmt.Errorf("task or variant not found: %s", taskName)
+}
+
+func (t *task) unlink(conf *config) error {
+	for _, currLink := range t.deps(conf) {
+		if err := unlinkTask(currLink, conf); err != nil {
+			return err
+		}
+	}
+
+	for _, currLink := range t.Links {
+		if err := removeLink(currLink, conf); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func unlinkTask(taskName string, conf *config) error {
+	for _, tn := range makeVariantNames(taskName, conf.variant) {
+		t, ok := conf.Tasks[tn]
+		if !ok {
+			continue
+		}
+
+		if conf.handled[tn] {
+			if conf.verbose {
+				log.Printf("skipping processed task: %s", tn)
+			}
+
+			return nil
+		}
+
+		if conf.verbose {
+			log.Printf("unlinking task: %s", tn)
+		}
+
+		return t.unlink(conf)
 	}
 
 	return fmt.Errorf("task or variant not found: %s", taskName)

--- a/task.go
+++ b/task.go
@@ -28,11 +28,11 @@ import (
 )
 
 type task struct {
-	Deps  []string
-	Links [][]string
-	Cmds  [][]string
-	Envs  [][]string
-	Encs  []string
+	Deps    []string
+	Links   [][]string
+	Cmds    [][]string
+	Envs    [][]string
+	Secrets []string
 }
 
 func (t *task) deps(conf *config) []string {
@@ -54,7 +54,7 @@ func (t *task) process(conf *config, key string) error {
 		}
 	}
 
-	for _, currEnc := range t.Encs {
+	for _, currEnc := range t.Secrets {
 		if err := processEnc(currEnc, conf, key); err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func processTask(taskName string, conf *config) error {
 		}
 
 		var key string
-		if len(t.Encs) != 0 {
+		if len(t.Secrets) != 0 {
 			fmt.Printf("Enter your password for %s: ", tn)
 			k, err := readKey()
 			if err != nil {
@@ -128,7 +128,7 @@ func (t *task) encrypt(conf *config, key string) error {
 		}
 	}
 
-	for _, currEnc := range t.Encs {
+	for _, currEnc := range t.Secrets {
 		if err := encryptEnc(currEnc, conf, key); err != nil {
 			return err
 		}
@@ -157,7 +157,7 @@ func encryptTask(taskName string, conf *config) error {
 		}
 
 		var key string
-		if len(t.Encs) != 0 {
+		if len(t.Secrets) != 0 {
 			fmt.Printf("Enter your password for %s: ", tn)
 			k, err := readKey()
 			if err != nil {


### PR DESCRIPTION
This PR brings quite a bit of changes. Instead of using the standard flags, `https://github.com/codegangsta/cli.git` was implemented to use subcommands, global flags, and subcommand flags. Additionally an encryption option was added that provides encryption on a per-task basis. This is useful for things like ssh keys. Storing your ssh keys and other sensitive files in your github repo can now be secure and allows a user to keep all things under a common repo. This makes bootstrapping/deploying much easier.
