### PR TITLE
Don't create a blank template when parsing templates

### DIFF
--- a/template.go
+++ b/template.go
@@ -104,7 +104,7 @@ func processTemplate(params []string, conf *config) (err error) {
 		log.Printf("process template %s to %s", srcPathAbs, dstPathAbs)
 	}
 
-	t, err := template.New(srcPath).ParseFiles(srcPathAbs)
+	t, err := template.ParseFiles(srcPathAbs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I ran across a bug where using a template in a subdirectory would fail because it was reading an empty template. Here's the task I was using:
```toml
[tasks.setup_git]
templates = [
  [".gitconfig.d/user.inc", "git/user.inc.tmpl"]
]
```
Using template.New() created a new, empty-content template with the name "git/user.inc.tmpl".
Afterwards, using .ParseFiles() creates another template with the name "user.inc.tmpl" with my template.
Finally, when .Execute is called, it picked the first, empty template "git/user.inc.tmpl".

This works fine when you don't place templates in subdirectories, as the name you generate matches the name .ParseFiles() does (and therefore gets clobbered with real content).

Using template.ParseTemplate() directly makes the first (and default) template for .Execute the file the user provides.