### PR TITLE
Continue to next file / task when pressing 'n' at clobber prompt

### DIFF
--- a/link.go
+++ b/link.go
@@ -30,52 +30,6 @@ import (
 	"strconv"
 )
 
-func cleanPath(loc string, flags int) (bool, error) {
-	if info, _ := os.Lstat(loc); info != nil {
-		if info.Mode()&os.ModeSymlink == 0 {
-			shouldContinue := false
-			if flags&flagClobber == 0 {
-				shouldContinue = prompt("clobber path", loc)
-			}
-			if flags&flagClobber != 0 || shouldContinue {
-				if flags&flagVerbose != 0 {
-					log.Printf("clobbering path: %s", loc)
-				}
-				if err := try(func() error { return os.RemoveAll(loc) }) ; err != nil {
-					return false, err
-				}
-			} else {
-				return false, nil
-			}
-		} else {
-			if flags&flagVerbose != 0 {
-				log.Printf("removing symlink: %s", loc)
-			}
-			if err := try(func() error { return os.Remove(loc) }); err != nil {
-				return false, err
-			}
-		}
-	}
-	return true, nil
-}
-
-func createPath(loc string, flags int, mode os.FileMode) error {
-	parentDir := path.Dir(loc)
-
-	if _, err := os.Stat(parentDir); os.IsNotExist(err) {
-		if flags&flagForce != 0 || prompt("force create path", parentDir) {
-			if flags&flagVerbose != 0 {
-				log.Printf("force creating path: %s", parentDir)
-			}
-			if err := os.MkdirAll(parentDir, mode); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 func parseLink(params []string) (srcPath, dstPath string, mode os.FileMode, err error) {
 	length := len(params)
 	if length < 1 || length > 3 {

--- a/template.go
+++ b/template.go
@@ -96,8 +96,12 @@ func processTemplate(params []string, conf *config) (err error) {
 		return err
 	}
 
-	if err = try(func() error { return cleanPath(dstPathAbs, conf.flags) }); err != nil {
+	pathCleaned, err := cleanPath(dstPathAbs, conf.flags)
+	if err != nil {
 		return err
+	}
+	if !pathCleaned {
+		return nil
 	}
 
 	if conf.flags&flagVerbose != 0 {

--- a/util.go
+++ b/util.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -45,6 +46,52 @@ func makeAbsPath(path string) string {
 	}
 
 	return path
+}
+
+func cleanPath(loc string, flags int) (bool, error) {
+	if info, _ := os.Lstat(loc); info != nil {
+		if info.Mode()&os.ModeSymlink == 0 {
+			shouldContinue := false
+			if flags&flagClobber == 0 {
+				shouldContinue = prompt("clobber path", loc)
+			}
+			if flags&flagClobber != 0 || shouldContinue {
+				if flags&flagVerbose != 0 {
+					log.Printf("clobbering path: %s", loc)
+				}
+				if err := try(func() error { return os.RemoveAll(loc) }) ; err != nil {
+					return false, err
+				}
+			} else {
+				return false, nil
+			}
+		} else {
+			if flags&flagVerbose != 0 {
+				log.Printf("removing symlink: %s", loc)
+			}
+			if err := try(func() error { return os.Remove(loc) }); err != nil {
+				return false, err
+			}
+		}
+	}
+	return true, nil
+}
+
+func createPath(loc string, flags int, mode os.FileMode) error {
+	parentDir := path.Dir(loc)
+
+	if _, err := os.Stat(parentDir); os.IsNotExist(err) {
+		if flags&flagForce != 0 || prompt("force create path", parentDir) {
+			if flags&flagVerbose != 0 {
+				log.Printf("force creating path: %s", parentDir)
+			}
+			if err := os.MkdirAll(parentDir, mode); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func makeVariantNames(name, variant string) []string {


### PR DESCRIPTION
A prompt shows up if Homemaker detects an existing file when creating a link or running a template.
Pressing `n` might stop the problematic file from being removed, but homemaker will still continue:

> clobber path /home/johndoe/.rcfile: [y]es, [n]o? n
2021/09/13 15:22:53 linking /dotfiles/rcfile to /home/johndoe/.rcfile
symlink /dotfiles/rcfile /home/johndoe/.rcfile: Cannot create a file when that file already exists.: [a]bort, [r]etry, [c]ancel?

Pressing `c` will obviously mean that nothing has happened, but no such luck for templates:

> clobber path /home/johndoe/.aliasesfile: [y]es, [n]o? n
2021/09/13 15:24:26 process template /dotfiles/aliasesfile_template to /home/johndoe/.aliasesfile

At this point the target file is overwritten.

This PR shuffles the code around so that the `cleanPath()` function which shows the "clobber path" prompt can return a boolean, at which point the caller can decide to stop doing what it is doing.