### PR TITLE
Use filepath package throughout for Windows support

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 
 	"github.com/naoina/toml"
 	"gopkg.in/yaml.v2"
@@ -50,7 +50,7 @@ func newConfig(filename string) (*config, error) {
 	}
 
 	conf := &config{handled: make(map[string]bool)}
-	switch path.Ext(filename) {
+	switch filepath.Ext(filename) {
 	case ".json":
 		if err := json.Unmarshal(bytes, &conf); err != nil {
 			return nil, err

--- a/homemaker.go
+++ b/homemaker.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -43,7 +43,7 @@ const (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s [options] conf src\n", path.Base(os.Args[0]))
+	fmt.Fprintf(os.Stderr, "Usage: %s [options] conf src\n", filepath.Base(os.Args[0]))
 	fmt.Fprintf(os.Stderr, "https://foosoft.net/projects/homemaker/\n\n")
 	fmt.Fprintf(os.Stderr, "Parameters:\n")
 	flag.PrintDefaults()

--- a/link.go
+++ b/link.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 )
 
@@ -65,13 +65,13 @@ func processLink(params []string, conf *config) error {
 	}
 
 	srcPathAbs := srcPath
-	if !path.IsAbs(srcPathAbs) {
-		srcPathAbs = path.Join(conf.srcDir, srcPath)
+	if !filepath.IsAbs(srcPathAbs) {
+		srcPathAbs = filepath.Join(conf.srcDir, srcPath)
 	}
 
 	dstPathAbs := dstPath
-	if !path.IsAbs(dstPathAbs) {
-		dstPathAbs = path.Join(conf.dstDir, dstPath)
+	if !filepath.IsAbs(dstPathAbs) {
+		dstPathAbs = filepath.Join(conf.dstDir, dstPath)
 	}
 
 	if conf.flags&flagUnlink != flagUnlink {

--- a/template.go
+++ b/template.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
@@ -79,13 +79,13 @@ func processTemplate(params []string, conf *config) (err error) {
 	}
 
 	srcPathAbs := srcPath
-	if !path.IsAbs(srcPathAbs) {
-		srcPathAbs = path.Join(conf.srcDir, srcPath)
+	if !filepath.IsAbs(srcPathAbs) {
+		srcPathAbs = filepath.Join(conf.srcDir, srcPath)
 	}
 
 	dstPathAbs := dstPath
-	if !path.IsAbs(dstPathAbs) {
-		dstPathAbs = path.Join(conf.dstDir, dstPath)
+	if !filepath.IsAbs(dstPathAbs) {
+		dstPathAbs = filepath.Join(conf.dstDir, dstPath)
 	}
 
 	if _, err = os.Stat(srcPathAbs); os.IsNotExist(err) {

--- a/util.go
+++ b/util.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 )
@@ -78,7 +77,7 @@ func cleanPath(loc string, flags int) (bool, error) {
 }
 
 func createPath(loc string, flags int, mode os.FileMode) error {
-	parentDir := path.Dir(loc)
+	parentDir := filepath.Dir(loc)
 
 	if _, err := os.Stat(parentDir); os.IsNotExist(err) {
 		if flags&flagForce != 0 || prompt("force create path", parentDir) {


### PR DESCRIPTION
The "path" package supports only forward slashes in paths, like those found in *nix operating systems or URLs.

Meanwhile Windows with its CP/M and QDOS ancestry requires drive letters and backslashes, and thus the "filepath" package needs to be used. This packages handles all the gnarly edge cases on different platforms and will make sure that all paths are properly normalized.

I've been able to use homemaker on Windows without this fix, but the experience has been bad.